### PR TITLE
doc: added developer instructions for Linux (Ubuntu)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/
 /packages/
 .idea
 **/.DS_Store
+.vscode

--- a/FishingJournal/FishingJournal.csproj
+++ b/FishingJournal/FishingJournal.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.3" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.3" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.0.3" />
         <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />

--- a/FishingJournal/appsettings.json.example
+++ b/FishingJournal/appsettings.json.example
@@ -1,4 +1,11 @@
 {
+  "Comments": [
+    "**** These comments are ignored, feel free to keep them or delete them ****",
+    "ConnectionStrings depend on your database, driver, and possibly other things",
+    "This sample app uses SQLServer; replacing that with SQLite is possible but non-trivial",
+    "Here is an example of a ConnectionString for a locally running SQLServer:",
+    "Example: \"DefaultConnection\": \"Server=localhost;Database=fishingjournal;User Id=SA;Password=Password1;\""
+  ],
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/README.md
+++ b/README.md
@@ -26,11 +26,54 @@ The purpose of this project is to serve as a home for learning and experimenting
 ## Appendix
 ### Useful Commands
 * drop all database tables: `dotnet ef database drop -f -v -c DefaultContext`
-* migrate database to latest version: `dotnet ef database update -c DefaultContext`
+* migrate database to latest version (i.e. run migrations): `dotnet ef database update -v -c DefaultContext`
 * simple scaffolding (requires model): `dotnet aspnet-codegenerator controller -name <controller name> -m <model name> -dc DefaultContext --relativeFolderPath Controllers`
 * add a migration: `dotnet ef migrations add <model name> -c DefaultContext`
-* run migrations: `dotnet database update -c DefaultContext`
+
 
 ### Useful Links
 * Integration test design inspired by: https://www.dotnetcurry.com/aspnet-core/1420/integration-testing-aspnet-core & https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-3.1
 * MSFT Identity scaffold documentation is both incorrect and inflexible for those not wanting to use Bootstrap & JQuery.  The design in this solution is inspired by: https://www.tektutorialshub.com/asp-net-core/asp-net-core-identity-tutorial/#configuring-the-identity-services
+
+
+# Linux (Ubuntu) Instructions
+
+## Prerequisites
+* npm: `sudo apt install npm`
+* .NET Core SDK and .NET Core Runtime (instructions: https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1910)
+* Entity Framework: `dotnet tool install --global dotnet-ef`
+* SQL Server (instructions: https://docs.microsoft.com/en-us/sql/linux/quickstart-install-connect-ubuntu?view=sql-server-ver15)  
+  * Password: `MS-sqlserver`
+  * As the instructions say, verify that the server is running by executing `systemctl status mssql-server --no-pager` after installation. You should get output similar to this (timestamp and PID will vary):
+  ```bash
+  ● mssql-server.service - Microsoft SQL Server Database Engine
+   Loaded: loaded (/lib/systemd/system/mssql-server.service; enabled; vendor preset: enabled)
+   Active: active (running) since Sat 2020-03-21 15:37:07 CDT; 47s ago
+     Docs: https://docs.microsoft.com/en-us/sql/linux
+   Main PID: 8018 (sqlservr)
+    Tasks: 150
+   CGroup: /system.slice/mssql-server.service
+           ├─8018 /opt/mssql/bin/sqlservr
+           └─8056 /opt/mssql/bin/sqlservr
+  ```
+* Verify that you can connect to your database by running `sqlcmd -S localhost -U SA -P '<YourPassword>'` on your shell.
+
+* ~~SQLite: `sudo apt-get install libsqlite3-dev`~~
+
+## Developer setup (via CLI)
+
+1. git clone <project url>
+2. `cd fishing-journal` (move into solution folder)
+3. `cd FishingJournal` (move into project folder)
+4. `dotnet add package Microsoft.EntityFrameworkCore.Sqlite` (Install Entity Framework Core)
+4. `cp appsettings.json.example appsettings.json`
+
+## References
+
+1. https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1910)
+2. https://docs.microsoft.com/en-us/ef/core/get-started/?tabs=netcore-cli
+3. If you get "`Cannot find command dotnet ef`" error:  
+    a. https://github.com/dotnet/efcore/issues/15448  
+    b. https://ardalis.com/dotnet-ef-does-not-exist
+5. https://dotnet.today/en/entity-framework-7/platforms/coreclr/getting-started-linux.html
+6. https://docs.microsoft.com/en-us/sql/linux/quickstart-install-connect-ubuntu?view=sql-server-ver15


### PR DESCRIPTION
Added instructions on how to build this on Linux (ubuntu).
Added non-breaking comments to appsettings.json.example to help craft connectionstrings for locally running MS SQLServer.